### PR TITLE
Logs

### DIFF
--- a/lib/cfn.js
+++ b/lib/cfn.js
@@ -67,25 +67,29 @@ CloudFormationEvent.prototype.send = function (body) {
 };
 
 CloudFormationEvent.prototype.failed = function (reason) {
-  this.send({
+  var r = {
     Status: 'FAILED',
     Reason: util.format('%s (%s)', reason, this.context.logStreamName),
     StackId: this.StackId,
     RequestId: this.RequestId,
     LogicalResourceId: this.LogicalResourceId,
     PhysicalResourceId: this.getPhysicalResourceId()
-  });
+  };
+  this.log.warn(r, "signalling failed");
+  this.send(r);
 };
 
 CloudFormationEvent.prototype.success = function (physicalResourceId, data) {
-  this.send({
+  var r = {
     Status: 'SUCCESS',
     StackId: this.StackId,
     RequestId: this.RequestId,
     LogicalResourceId: this.LogicalResourceId,
     PhysicalResourceId: physicalResourceId || this.getPhysicalResourceId(),
     Data: data || undefined
-  });
+  };
+  this.log.info(r, 'signalling success');
+  this.send(r);
 };
 
 CloudFormationEvent.prototype.getPhysicalResourceId = function () {

--- a/lib/cfn.js
+++ b/lib/cfn.js
@@ -47,7 +47,7 @@ CloudFormationEvent.prototype.send = function (body) {
     attemptCount += 1;
 
     var request = https.request(options, function (response) {
-      log.info({ code: response.statusCode, status: response.statusMessage  }, 'Custom Resource Response Sent\n%s', responseBody);
+      log.info({ code: response.statusCode, status: response.statusMessage, body: body }, 'Custom Resource Response Sent');
       context.done();
     });
 

--- a/lib/cfn.js
+++ b/lib/cfn.js
@@ -8,7 +8,7 @@ var util = require('util');
 function CloudFormationEvent (event, context, log) {
   _.assign(this, event);
   this.context = context;
-  this.log = log;
+  this.log = log.child({type: 'CloudFormationEvent'});
 
   // arn:aws:cloudformation:us-east-1:123456789012:stack/mystack-mynestedstack-sggfrhxhum7w/f449b250-b969-11e0-a185-5081d0136786
   var stackId = this.StackId.split(':');

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -13,7 +13,7 @@ exports.handler = function (resources) {
   var Q = require('q');
 
   return function (event, context) {
-    var log = bunyan.createLogger({ name: event.ResourceType });
+    var log = bunyan.createLogger({ name: event.ResourceType, type: 'root' });
 
     log.info({ Event: event, Context: context }, 'Custom Resource Request Received');
     var cfnEvent = new exports.cfn.CloudFormationEvent(event, context, log);


### PR DESCRIPTION
* decorate bunyan log events with `type` field to easily distinguish
* put the response body into the log event, not the message - more useful
* log from `failed` and `success`