### PR TITLE
chore: Update repo ownership (PD-190851)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@bazaarvoice/cloud-engineering

--- a/OWNERS
+++ b/OWNERS
@@ -1,1 +1,0 @@
-infrastructure-dev@bazaarvoice.com


### PR DESCRIPTION
PD-190851

- Adds @bazaarvoice/cloud-engineering as `CODEOWNERS` 
- Removes `OWNERS` so that we use `CODEOWNERS` exclusively